### PR TITLE
Proxy support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "url": "https://github.com/k3rn31p4nic/google-translate-api/issues"
   },
   "dependencies": {
-    "got": "^9.2.2"
+    "got": "^9.2.2",
+    "tunnel": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^5.6.1"

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ async function translate(text, options) {
 
       requestOptions[1] = {
         agent: tunnel.httpOverHttp({
-          proxy: proxies[0]
+          proxy: proxies[Math.floor(Math.random() * proxies.length)]
         })
       };
     }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const languages = require('./languages');
 const tokenGenerator = require('./tokenGenerator');
 const querystring = require('querystring');
 const got = require('got');
+const tunnel = require('tunnel');
 
 /**
  * @function translate
@@ -78,6 +79,16 @@ async function translate(text, options) {
       requestOptions = [ url ];
     }
 
+    let proxies = [];
+    if (Array.isArray(options.proxies)) {
+      proxies = options.proxies;
+
+      requestOptions[1] = {
+        agent: tunnel.httpOverHttp({
+          proxy: proxies[0]
+        })
+      };
+    }
     // Request translation from Google Translate.
     let response = await got(...requestOptions);
 


### PR DESCRIPTION
Usage

```js

const t = require('@k3rn31p4nic/google-translate-api');

const resp = t('Hello', {
  from: 'en',
  to: 'ru',

  proxies: [
    { host: '134.209.1.204', port: 8080 }
  ]
});

resp.then(x => {
  console.log(x);
}).catch(x => {
  console.log(x);
});

```

I didn't check proxy above