### PR TITLE
fix!: tidy the public API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,19 @@ translate(text, options).then(console.log).catch(console.error);
 | `from.text.autoCorrected` | `Boolean` | Whether or not the API has auto corrected the original text. |
 | `from.text.value` | `String` | The auto corrected text or the text with suggested corrections. Only returned if `from.text.autoCorrected` or `from.text.didYouMean` is `true`. |
 | `from.text.didYouMean` | `Boolean` | Wherether or not the API has suggested corrections to the text |
-| `raw` | `String` | The raw response from Google Translate servers. Only returned if `options.raw` is `true` in the request options. |
+| `raw` | `Array` | The raw response from Google Translate servers, or `""` unless `options.raw` is `true` in the request options. |
+
+
+## Languages
+`translate.languages` is the table of supported languages, keyed by code, with two helpers attached.
+
+```js
+translate.languages['pa-Arab'];              // OUTPUT: Punjabi (Shahmukhi)
+translate.languages.getISOCode('Spanish');   // OUTPUT: es
+translate.languages.isSupported('klingon');  // OUTPUT: false
+```
+
+`getISOCode` accepts a code or a display name, case insensitively, and returns the code in its canonical casing or `null` if it isn't supported. The helpers are non-enumerable, so iterating the table yields only languages.
 
 
 ## Errors

--- a/src/index.js
+++ b/src/index.js
@@ -24,10 +24,10 @@ async function translate(text, options) {
     });
     if (error) throw error;
 
-    // If options object doesn"t have "from" language, set it to "auto".
-    if (!Object.prototype.hasOwnProperty.call(options, "from")) options.from = "auto";
-    // If options object doesn"t have "to" language, set it to "en".
-    if (!Object.prototype.hasOwnProperty.call(options, "to")) options.to = "en";
+    // If options object doesn't have a "from" language, set it to "auto".
+    if (!options.from) options.from = "auto";
+    // If options object doesn't have a "to" language, set it to "en".
+    if (!options.to) options.to = "en";
     // If options object has a "raw" property evaluating to true, set it to true.
     options.raw = Boolean(options.raw);
 

--- a/src/languages.js
+++ b/src/languages.js
@@ -261,16 +261,16 @@ const languages = {
 };
 
 /**
- * Returns the code of the desiredLang – if it is supported by Google Translate
+ * Returns the code of the language – if it is supported by Google Translate
  *
  * Matching is case insensitive, but the code is returned with the casing of
  * the table, as Google reads the script subtag (e.g. crh-Latn) as significant.
  * @param {string} language The name or the code of the desired language
- * @returns {string|boolean} The code of the language, null if the language is
- * not supported, or false if no language was given
+ * @returns {string|null} The code of the language, or null if it is not
+ * supported
  */
 function getISOCode(language) {
-    if (!language) return false;
+    if (!language) return null;
     let query = String(language).toLowerCase();
 
     let codes = Object.keys(languages).filter((key) => typeof languages[key] === "string");

--- a/src/languages.js
+++ b/src/languages.js
@@ -291,5 +291,6 @@ function isSupported(language) {
 }
 
 module.exports = languages;
-module.exports.isSupported = isSupported;
-module.exports.getISOCode = getISOCode;
+
+Object.defineProperty(module.exports, "isSupported", { value: isSupported });
+Object.defineProperty(module.exports, "getISOCode", { value: getISOCode });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -33,9 +33,22 @@ declare namespace translate {
                 didYouMean: boolean;
             };
         };
-        /** The raw response from Google Translate servers. Only returned if `options.raw` is `true` in the request options. */
-        raw: string;
+        /** The raw response from Google Translate servers, or `""` unless `options.raw` is `true` in the request options. */
+        raw: unknown[] | "";
     }
+
+    /** The languages Google Translate supports, keyed by code. */
+    type LanguageTable = {
+        readonly [code: string]: string;
+    };
+
+    /** The language table, with its non-enumerable lookup helpers attached. */
+    type Languages = LanguageTable & {
+        /** Returns the code for a language name or code, case insensitively, or null if unsupported. */
+        getISOCode(language: string): string | null;
+        /** Returns whether the given code or display name is supported. */
+        isSupported(language: string): boolean;
+    };
 
     /** The error thrown when `options.from` or `options.to` is not a language Google Translate supports. */
     interface UnsupportedLanguageError extends Error {
@@ -56,6 +69,8 @@ declare namespace translate {
 
     /** Any error `translate` rejects with. Narrow it on `name`. */
     type TranslateError = UnsupportedLanguageError | TranslateResponseError;
+
+    const languages: Languages;
 }
 
 export = translate;


### PR DESCRIPTION
`getISOCode` had three return types — the code on a hit, `null` for an unsupported language, `false` when given nothing. It returns `null` for both failure cases now.

That `false` was reaching the wire. `{ from: "" }` skipped the validation loop, which only checks truthy languages, so `getISOCode` returned `false` and `sl=false` went to Google. `{ from: undefined }` hit the same path, which is what forwarding an absent value produces. Empty and missing languages both fall back to the defaults now, so the check for a supplied language is truthiness rather than `hasOwnProperty`.

The typings declared only the `translate` function, so `translate.languages` and its helpers were invisible to TypeScript and had to be reached through a cast. They're declared now, with the table as a readonly code-to-name map, and documented in the README.

That map is only honest if the table holds nothing but strings, and both helpers were enumerable properties of the same object — so `Object.keys(languages).map(c => languages[c].toLowerCase())` type-checked and then crashed on a function. They're non-enumerable now.

`raw` was typed `string` but holds the parsed response array when `options.raw` is true, and `""` otherwise.

### Breaking

- `getISOCode` returns `null` instead of `false` for empty input. `isSupported` is unchanged, as both sentinels are falsy.
- `TranslateResponse.raw` is typed `unknown[] | ""` rather than `string`. Assigning it to a string never worked at runtime but now fails to compile.
- `Object.keys` and `JSON.stringify` on the `languages` export no longer include `isSupported` or `getISOCode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
