### PR TITLE
docs!: correct the README, rename getISOCode to getCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ translate(text, options).then(console.log).catch(console.error);
 
 ```js
 translate.languages['pa-Arab'];              // OUTPUT: Punjabi (Shahmukhi)
-translate.languages.getISOCode('Spanish');   // OUTPUT: es
+translate.languages.getCode('Spanish');   // OUTPUT: es
 translate.languages.isSupported('klingon');  // OUTPUT: false
 ```
 
-`getISOCode` accepts a code or a display name, case insensitively, and returns the code in its canonical casing or `null` if it isn't supported. The helpers are non-enumerable, so iterating the table yields only languages.
+`getCode` accepts a code or a display name, case insensitively, and returns the code in its canonical casing or `null` if it isn't supported. The helpers are non-enumerable, so iterating the table yields only languages.
 
 
 ## Errors

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 A [Node.JS](https://nodejs.org) library to consume Google Translate for free.
 
 [![GitHub release](https://img.shields.io/github/release/iamtraction/google-translate.svg?style=flat)](https://github.com/iamtraction/google-translate/releases)
-[![Dependencies](https://david-dm.org/iamtraction/google-translate.svg)](https://david-dm.org/iamtraction/google-translate)
 [![Known Vulnerabilities](https://snyk.io/test/github/iamtraction/google-translate/badge.svg?targetFile=package.json)](https://snyk.io/test/github/iamtraction/google-translate?targetFile=package.json)
 [![license](https://img.shields.io/github/license/iamtraction/google-translate.svg)](LICENSE)
 
@@ -15,10 +14,14 @@ A [Node.JS](https://nodejs.org) library to consume Google Translate for free.
 ## Table of Contents
 * [Installation](#installation)
 * [Usage](#usage)
+* [Languages](#languages)
+* [Errors](#errors)
 * [Examples](#examples)
 * [Credits, etc](#extras)
 
 ## Installation
+Requires Node.js 22.19.0 or later.
+
 ```bash
 # Stable version, from npm repository
 npm install --save @iamtraction/google-translate
@@ -29,11 +32,7 @@ npm install --save iamtraction/google-translate
 
 ## Usage
 ```js
-// If you've installed from npm, do:
 const translate = require('@iamtraction/google-translate');
-
-// If you've installed from GitHub, do:
-const translate = require('google-translate');
 ```
 
 #### Method: `translate(text, options)`
@@ -44,8 +43,8 @@ translate(text, options).then(console.log).catch(console.error);
 |-|-|-|-|-|
 | `text` | `String` | No | - | The text you want to translate. |
 | `options` | `Object` | - | - | The options for translating. |
-| `options.from` | `String` | Yes | `'auto'` | The language name/ISO 639-1 code to translate from. If none is given, it will auto detect the source language. |
-| `options.to` | `String` | Yes | `'en'` | The language name/ISO 639-1 code to translate to. If none is given, it will translate to English. |
+| `options.from` | `String` | Yes | `'auto'` | The language name or code to translate from. If none is given, it will auto detect the source language. |
+| `options.to` | `String` | Yes | `'en'` | The language name or code to translate to. If none is given, it will translate to English. |
 | `options.raw` | `Boolean` | Yes | `false` | If `true`, it will return the raw output that was received from Google Translate. |
 
 #### Returns: `Promise<Object>`
@@ -57,10 +56,10 @@ translate(text, options).then(console.log).catch(console.error);
 | `from` | `Object` | - |
 | `from.language` | `Object` | - |
 | `from.language.didYouMean` | `Boolean` | Whether or not the API suggest a correction in the source language. |
-| `from.language.iso` | `String` | The ISO 639-1 code of the language that the API has recognized in the text. |
+| `from.language.iso` | `String` | The code of the language that the API has recognized in the text. |
 | `from.text` | `Object` | - |
 | `from.text.autoCorrected` | `Boolean` | Whether or not the API has auto corrected the original text. |
-| `from.text.value` | `String` | The auto corrected text or the text with suggested corrections. Only returned if `from.text.autoCorrected` or `from.text.didYouMean` is `true`. |
+| `from.text.value` | `String` | The auto corrected text or the text with suggested corrections, or `""` unless `from.text.autoCorrected` or `from.text.didYouMean` is `true`. |
 | `from.text.didYouMean` | `Boolean` | Wherether or not the API has suggested corrections to the text |
 | `raw` | `Array` | The raw response from Google Translate servers, or `""` unless `options.raw` is `true` in the request options. |
 
@@ -107,9 +106,9 @@ translate('Tu es incroyable!', { to: 'en' }).then(res => {
 
 #### From English to French, with a typo:
 ```js
-translate('Thank you', { from: 'en', to: 'fr' }).then(res => {
-  console.log(res.text); // OUTPUT: Je vous remercie
-  console.log(res.from.autoCorrected); // OUTPUT: true
+translate('Thnk you', { from: 'en', to: 'fr' }).then(res => {
+  console.log(res.text); // OUTPUT: Merci
+  console.log(res.from.text.autoCorrected); // OUTPUT: true
   console.log(res.from.text.value); // OUTPUT: [Thank] you
   console.log(res.from.text.didYouMean); // OUTPUT: false
 }).catch(err => {
@@ -119,10 +118,10 @@ translate('Thank you', { from: 'en', to: 'fr' }).then(res => {
 
 #### Sometimes Google Translate won't auto correct:
 ```js
-translate('Thank you', { from: 'en', to: 'fr' }).then(res => {
-  console.log(res.text); // OUTPUT: ''
-  console.log(res.from.autoCorrected); // OUTPUT: false
-  console.log(res.from.text.value); // OUTPUT: [Thank] you
+translate('I spea Dutch!', { from: 'en', to: 'nl' }).then(res => {
+  console.log(res.text); // OUTPUT: Ik spreek Nederlands!
+  console.log(res.from.text.autoCorrected); // OUTPUT: false
+  console.log(res.from.text.value); // OUTPUT: I [speak] Dutch!
   console.log(res.from.text.didYouMean); // OUTPUT: true
 }).catch(err => {
   console.error(err);

--- a/src/index.js
+++ b/src/index.js
@@ -32,8 +32,8 @@ async function translate(text, options) {
     options.raw = Boolean(options.raw);
 
     // Get the codes for the languages.
-    options.from = languages.getISOCode(options.from);
-    options.to = languages.getISOCode(options.to);
+    options.from = languages.getCode(options.from);
+    options.to = languages.getCode(options.to);
 
     // URL & query string required by Google Translate.
     let baseUrl = "https://translate.google.com/translate_a/single";

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ async function translate(text, options) {
     // If options object has a "raw" property evaluating to true, set it to true.
     options.raw = Boolean(options.raw);
 
-    // Get ISO 639-1 codes for the languages.
+    // Get the codes for the languages.
     options.from = languages.getISOCode(options.from);
     options.to = languages.getISOCode(options.to);
 

--- a/src/languages.js
+++ b/src/languages.js
@@ -282,8 +282,8 @@ function getISOCode(language) {
 }
 
 /**
- * Returns true if the desiredLang is supported by Google Translate and false otherwise
- * @param {String} language The ISO 639-1 code or the name of the desired language.
+ * Returns true if the language is supported by Google Translate and false otherwise
+ * @param {string} language The code or the name of the desired language.
  * @returns {boolean} If the language is supported or not.
  */
 function isSupported(language) {

--- a/src/languages.js
+++ b/src/languages.js
@@ -269,7 +269,7 @@ const languages = {
  * @returns {string|null} The code of the language, or null if it is not
  * supported
  */
-function getISOCode(language) {
+function getCode(language) {
     if (!language) return null;
     let query = String(language).toLowerCase();
 
@@ -287,10 +287,10 @@ function getISOCode(language) {
  * @returns {boolean} If the language is supported or not.
  */
 function isSupported(language) {
-    return Boolean(getISOCode(language));
+    return Boolean(getCode(language));
 }
 
 module.exports = languages;
 
 Object.defineProperty(module.exports, "isSupported", { value: isSupported });
-Object.defineProperty(module.exports, "getISOCode", { value: getISOCode });
+Object.defineProperty(module.exports, "getCode", { value: getCode });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6,9 +6,9 @@ declare function translate(text: string, options?: translate.TranslateOption): P
 
 declare namespace translate {
     interface TranslateOption {
-        /** The language name/ISO 639-1 code to translate from. If none is given, it will auto detect the source language. */
+        /** The language name or code to translate from. If none is given, it will auto detect the source language. */
         from?: string;
-        /** The language name/ISO 639-1 code to translate to. If none is given, it will translate to English. */
+        /** The language name or code to translate to. If none is given, it will translate to English. */
         to?: string;
         /** If `true`, it will return the raw output that was received from Google Translate. */
         raw?: boolean;
@@ -21,13 +21,13 @@ declare namespace translate {
             language: {
                 /** Whether or not the API suggest a correction in the source language. */
                 didYouMean: boolean;
-                /** The ISO 639-1 code of the language that the API has recognized in the text. */
+                /** The code of the language that the API has recognized in the text. */
                 iso: string;
             };
             text: {
                 /** Whether or not the API has auto corrected the original text. */
                 autoCorrected: boolean;
-                /** The auto corrected text or the text with suggested corrections. Only returned if `from.text.autoCorrected` or `from.text.didYouMean` is `true`. */
+                /** The auto corrected text or the text with suggested corrections, or `""` unless `from.text.autoCorrected` or `from.text.didYouMean` is `true`. */
                 value: string;
                 /** Wherether or not the API has suggested corrections to the text. */
                 didYouMean: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -45,7 +45,7 @@ declare namespace translate {
     /** The language table, with its non-enumerable lookup helpers attached. */
     type Languages = LanguageTable & {
         /** Returns the code for a language name or code, case insensitively, or null if unsupported. */
-        getISOCode(language: string): string | null;
+        getCode(language: string): string | null;
         /** Returns whether the given code or display name is supported. */
         isSupported(language: string): boolean;
     };


### PR DESCRIPTION
The dependencies badge pointed at david-dm.org, which is shut down and answers 500. Closes #49.

Both correction examples were wrong. They translated `'Thank you'`, which has no typo, so neither the `autoCorrected` nor the `didYouMean` path they claim to demonstrate was ever reached, and both logged `res.from.autoCorrected` — undefined, since the field is `res.from.text.autoCorrected`. They now use inputs that actually trigger each path, with the output Google returns.

The GitHub install told readers to `require('google-translate')`, but npm installs under the name in `package.json` whichever source it comes from, so only the scoped name resolves. The table of contents was missing the Languages and Errors sections, and the Node requirement wasn't stated anywhere.

### getISOCode → getCode

Only 151 of the 250 codes are ISO 639-1, which is two letters. The rest are 84 three-letter ISO 639-2/3 codes, 14 carrying a script or region subtag (`pa-Arab`, `zh-CN`, `iu-Latn`), and `auto`, which isn't a language. The name stopped being accurate when the table was refreshed. It reads as `languages.getCode`, so the namespace already says what's being looked up.

The same staleness was in `options.from`/`options.to`, `from.language.iso`, and the `isSupported` JSDoc; those now say "code".

### Breaking

- `languages.getISOCode` is now `languages.getCode`, with no alias.
- `from.text.value` is documented as always present rather than "only returned if" — it's `""` when there's no correction. Documentation only; the runtime is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
