### PR TITLE
fix: build the query without the querystring module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,23 @@
-const querystring = require("querystring");
 const { request } = require("undici");
 
 const languages = require("./languages");
+
+/**
+ * Serialises the query, repeating a key once per value for array values, as
+ * Google expects for `dt`
+ * @param {Object} query The query parameters.
+ * @returns {String} The encoded query string.
+ */
+function stringify(query) {
+    let params = new URLSearchParams();
+
+    for (let [ key, value ] of Object.entries(query)) {
+        if (Array.isArray(value)) value.forEach((item) => params.append(key, item));
+        else params.append(key, value);
+    }
+
+    return params.toString();
+}
 
 /**
  * @function translate
@@ -53,14 +69,14 @@ async function translate(text, options) {
     };
 
     // Append query string to the request URL.
-    let url = `${baseUrl}?${querystring.stringify(data)}`;
+    let url = `${baseUrl}?${stringify(data)}`;
 
     let requestOptions;
     // If request URL is greater than 2048 characters, use POST method.
     if (url.length > 2048) {
         delete data.q;
         requestOptions = [
-            `${baseUrl}?${querystring.stringify(data)}`,
+            `${baseUrl}?${stringify(data)}`,
             {
                 method: "POST",
                 body: new URLSearchParams({ q: text }).toString(),


### PR DESCRIPTION
`querystring` is a legacy Node API with a WHATWG replacement, and bundlers that only provide web globals can't resolve it — which is what breaks the package under Metro. Closes #44.

`URLSearchParams` can't be handed the query object directly: it joins the `dt` array into one comma-separated value, and Google needs the key repeated (`dt=at&dt=bd&…`). The helper appends array values one at a time.

The only difference in output is that spaces encode as `+` rather than `%20`. I checked against the live endpoint that both forms return identical translations, for plain and unicode input.

This doesn't make the package work under React Native on its own — `undici` is still Node-only — but it removes one blocker and drops a deprecated dependency regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
