### PR TITLE
Add a node:test suite

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,4 +25,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: npm
     - run: npm ci
+    - run: npm run lint
     - run: npm test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-# This workflow will run tests using node and then publish a package to npm when a release is created
+# This workflow publishes the package to npm when a release is created.
 
 name: Node.js Package
 
@@ -7,21 +7,8 @@ on:
     types: [ created ]
 
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-          cache: npm
-      - run: npm ci
-      - run: npm test
-
   publish-npm:
     name: Publish to npm
-    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -31,7 +18,10 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 24
+          cache: npm
           registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm run lint
       - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A [Node.JS](https://nodejs.org) library to consume Google Translate for free.
 * [Languages](#languages)
 * [Errors](#errors)
 * [Examples](#examples)
+* [Development](#development)
 * [Credits, etc](#extras)
 
 ## Installation
@@ -130,6 +131,19 @@ translate('I spea Dutch!', { from: 'en', to: 'nl' }).then(res => {
   console.error(err);
 });
 ```
+
+## Development
+```bash
+npm run lint          # ESLint
+npm test              # the test suite
+npm run test:coverage # the test suite with a coverage report for src/
+```
+
+Lint is separate from tests and is not run by `npm test` — CI runs it as its own step, and a habit of running `npm test` alone will skip it.
+
+Most of the suite runs offline: `languages`, `request`, `parse`, and `errors` mock the transport through the public `dispatcher` option, so they assert what this library does — the request it builds, how it parses the response, how it validates and reports errors — without a network call. Only `test/smoke.test.js` reaches the real `translate.google.com`, so a red run there may be Google rate limiting rather than a regression. It checks only that a live response still parses into the expected shape; whether a translation is *correct* is Google's concern, not this library's, so no test asserts translated content.
+
+To run just the offline suites: `node --test test/languages.test.js test/request.test.js test/parse.test.js test/errors.test.js`.
 
 ## Extras
 If you liked this project, please give it a ⭐ in [**GitHub**](https://github.com/iamtraction/google-translate).

--- a/fixtures/mock.js
+++ b/fixtures/mock.js
@@ -1,0 +1,31 @@
+const { MockAgent } = require("undici");
+
+const JSON_HEADERS = { "content-type": "application/json" };
+
+/**
+ * A MockAgent that answers the Google Translate endpoint once. Pass `capture`
+ * to record the request path and body the library sent.
+ * @param {Object} options Reply status/body/headers and an optional capture.
+ * @returns {MockAgent} A dispatcher to pass as options.dispatcher.
+ */
+function mockGoogle({ status = 200, body = "", jsonHeaders = true, capture } = {}) {
+    const agent = new MockAgent();
+    agent.disableNetConnect();
+    agent.get("https://translate.google.com")
+        .intercept({
+            path: (path) => {
+                if (capture) capture.path = path;
+                return path.startsWith("/translate_a/single");
+            },
+            method: () => true,
+            body: (requestBody) => {
+                if (capture) capture.body = requestBody;
+                return true;
+            }
+        })
+        .reply(status, body, jsonHeaders ? { headers: JSON_HEADERS } : undefined)
+        .times(1);
+    return agent;
+}
+
+module.exports = { mockGoogle };

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
         "typings"
     ],
     "scripts": {
-        "test:lint": "eslint .",
-        "test": "npm run test:lint"
+        "lint": "eslint .",
+        "test": "node --test",
+        "test:coverage": "node --test --experimental-test-coverage --test-coverage-include=\"src/**\""
     },
     "repository": {
         "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ function stringify(query) {
  * @returns {Object} The result containing the translation.
  */
 async function translate(text, options) {
-    if (typeof options !== "object") options = {};
+    if (typeof options !== "object" || options === null) options = {};
     text = String(text);
 
     // Check if a lanugage is in supported; if not, throw an error object.

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -1,0 +1,43 @@
+const assert = require("node:assert/strict");
+const { describe, test } = require("node:test");
+
+const { mockGoogle } = require("../fixtures/mock");
+const translate = require("../src/index");
+
+describe("translate rejections", () => {
+    test("rejects an unsupported language before any request", async () => {
+        // Validated before the network, so no dispatcher is needed.
+        await assert.rejects(translate("Hi", { to: "xx" }), (error) => {
+            assert.equal(error.name, "UnsupportedLanguageError");
+            assert.equal(error.code, 400);
+            return true;
+        });
+        await assert.rejects(translate("Hi", { from: "zz" }), (error) => {
+            assert.equal(error.name, "UnsupportedLanguageError");
+            return true;
+        });
+    });
+
+    test("maps a non-200 response to a TranslateResponseError", async (t) => {
+        const agent = mockGoogle({ status: 429, body: "<html>rate limited</html>", jsonHeaders: false });
+        t.after(() => agent.close());
+
+        await assert.rejects(translate("Hello", { dispatcher: agent }), (error) => {
+            assert.equal(error.name, "TranslateResponseError");
+            assert.equal(error.code, 429);
+            return true;
+        });
+    });
+
+    test("maps a malformed body to a 502 and keeps the parse failure as the cause", async (t) => {
+        const agent = mockGoogle({ status: 200, body: "this is not json", jsonHeaders: false });
+        t.after(() => agent.close());
+
+        await assert.rejects(translate("Hello", { dispatcher: agent }), (error) => {
+            assert.equal(error.name, "TranslateResponseError");
+            assert.equal(error.code, 502);
+            assert.ok(error.cause, "the parse failure should be kept as the cause");
+            return true;
+        });
+    });
+});

--- a/test/languages.test.js
+++ b/test/languages.test.js
@@ -1,0 +1,16 @@
+const assert = require("node:assert/strict");
+const { describe, test } = require("node:test");
+
+const languages = require("../src/languages");
+
+describe("languages", () => {
+    test("getCode resolves codes and names and reports the unknown", () => {
+        assert.equal(languages.getCode("en"), "en");
+        assert.equal(languages.getCode("EN"), "en");
+        assert.equal(languages.getCode("Spanish"), "es");
+        // The code keeps the table's casing; Google treats the script subtag as significant.
+        assert.equal(languages.getCode("crh-latn"), "crh-Latn");
+        assert.equal(languages.getCode("xx"), null);
+        assert.equal(languages.getCode(""), null);
+    });
+});

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -1,0 +1,71 @@
+const assert = require("node:assert/strict");
+const { describe, test } = require("node:test");
+
+const { mockGoogle } = require("../fixtures/mock");
+const translate = require("../src/index");
+
+// Canned response bodies, so each parsing branch is hit deterministically. The
+// input text is irrelevant; only the reply matters.
+function respondingWith(body) {
+    return mockGoogle({ body: JSON.stringify(body) });
+}
+
+describe("response parsing (mocked dispatcher)", () => {
+    test("joins the text, reads the detected language, and exposes raw on request", async (t) => {
+        const body = [
+            [
+                [ "Hello ", "x", null, null, 0 ],
+                [ "world", "y", null, null, 0 ],
+                [ null, "z" ]
+            ],
+            null,
+            "en",
+            null, null, null, null, null,
+            [ [ "en" ], null, [ 1 ], [ "en" ] ]
+        ];
+        const first = respondingWith(body);
+        const second = respondingWith(body);
+        t.after(async () => { await first.close(); await second.close(); });
+
+        const result = await translate("whatever", { dispatcher: first });
+        assert.equal(result.text, "Hello world");
+        assert.equal(result.from.language.iso, "en");
+        assert.equal(result.from.language.didYouMean, false);
+        assert.equal(result.from.text.value, "");
+        assert.equal(result.raw, "");
+
+        const withRaw = await translate("whatever", { raw: true, dispatcher: second });
+        assert.deepEqual(withRaw.raw, body);
+    });
+
+    test("flags didYouMean when the detected language disagrees with the echo", async (t) => {
+        const agent = respondingWith([
+            [ [ "Hello", "Hola", null, null, 0 ] ],
+            null,
+            "en",
+            null, null, null, null, null,
+            [ [ "es" ], null, [ 1 ], [ "es" ] ]
+        ]);
+        t.after(() => agent.close());
+
+        const result = await translate("whatever", { dispatcher: agent });
+        assert.equal(result.from.language.didYouMean, true);
+        assert.equal(result.from.language.iso, "es");
+    });
+
+    test("unwraps a source-text correction and flags it", async (t) => {
+        const agent = respondingWith([
+            [ [ "Hello", "Helo", null, null, 0 ] ],
+            null,
+            "en",
+            null, null, null, null,
+            [ "<b><i>Hello</i></b> world", null, null, null, null, true ],
+            [ [ "en" ], null, [ 1 ], [ "en" ] ]
+        ]);
+        t.after(() => agent.close());
+
+        const result = await translate("whatever", { dispatcher: agent });
+        assert.equal(result.from.text.value, "[Hello] world");
+        assert.equal(result.from.text.autoCorrected, true);
+    });
+});

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -1,0 +1,79 @@
+const assert = require("node:assert/strict");
+const { describe, test } = require("node:test");
+const { MockAgent, setGlobalDispatcher, getGlobalDispatcher } = require("undici");
+
+const { mockGoogle } = require("../fixtures/mock");
+const translate = require("../src/index");
+
+// A well-formed reply, so translate() gets far enough to send its request.
+const OK = JSON.stringify([
+    [ [ "x", "y", null, null, 0 ] ],
+    null,
+    "en",
+    null, null, null, null, null,
+    [ [ "en" ], null, [ 1 ], [ "en" ] ]
+]);
+
+function query(path) {
+    return new URLSearchParams(path.split("?")[1]);
+}
+
+describe("request building (mocked dispatcher)", () => {
+    test("builds the query from the options, resolving names and repeating dt", async (t) => {
+        const defaults = {};
+        const explicit = {};
+        const a = mockGoogle({ body: OK, capture: defaults });
+        const b = mockGoogle({ body: OK, capture: explicit });
+        t.after(async () => { await a.close(); await b.close(); });
+
+        await translate("Hola", { dispatcher: a });
+        const dq = query(defaults.path);
+        assert.equal(dq.get("sl"), "auto");
+        assert.equal(dq.get("tl"), "en");
+        assert.equal(dq.get("q"), "Hola");
+        // dt is repeated, not comma-joined (URLSearchParams would join an array).
+        assert.ok(dq.getAll("dt").length > 1, "dt must repeat once per value");
+        assert.ok(!defaults.path.includes("%2C"), "dt must not be comma-joined");
+
+        await translate("Hola", { from: "French", to: "Spanish", dispatcher: b });
+        const eq = query(explicit.path);
+        assert.equal(eq.get("sl"), "fr");
+        assert.equal(eq.get("tl"), "es");
+    });
+
+    test("moves the text to the request body when the URL would be too long", async (t) => {
+        const captured = {};
+        const agent = mockGoogle({ body: OK, capture: captured });
+        t.after(() => agent.close());
+
+        const text = "The quick brown fox jumps over the lazy dog. ".repeat(50);
+        assert.ok(text.length > 2048, "the fixture is too short to trip the POST branch");
+
+        await translate(text, { dispatcher: agent });
+
+        // Past 2048 characters q moves from the URL into the body.
+        assert.equal(query(captured.path).get("q"), null);
+        assert.ok(captured.path.length <= 2048, "the URL should no longer be oversized");
+        assert.equal(new URLSearchParams(captured.body).get("q"), text);
+    });
+
+    test("tolerates a missing or non-object options argument", async (t) => {
+        // null is typeof "object", so it needs its own guard or options.from
+        // throws. No dispatcher is passed, so a global mock stands in.
+        const previous = getGlobalDispatcher();
+        const agent = new MockAgent();
+        agent.disableNetConnect();
+        agent.get("https://translate.google.com")
+            .intercept({ path: () => true, method: () => true })
+            .reply(200, OK, { headers: { "content-type": "application/json" } })
+            .times(2);
+        setGlobalDispatcher(agent);
+        t.after(async () => {
+            setGlobalDispatcher(previous);
+            await agent.close();
+        });
+
+        assert.equal(typeof (await translate("hi")).text, "string");
+        assert.equal(typeof (await translate("hi", null)).text, "string");
+    });
+});

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,0 +1,21 @@
+const assert = require("node:assert/strict");
+const { describe, test } = require("node:test");
+
+const translate = require("../src/index");
+
+describe("live smoke (real endpoint, shape only)", () => {
+    // Hits the real endpoint. Asserts shape, not content -- whether a translation
+    // is correct is Google's job, not this library's.
+    test("a real response parses into our result shape", { timeout: 15000 }, async () => {
+        const result = await translate("hello");
+
+        assert.equal(typeof result.text, "string");
+        assert.ok(result.text.length > 0);
+        assert.equal(typeof result.from.language.iso, "string");
+        assert.ok(result.from.language.iso.length > 0);
+        assert.equal(typeof result.from.language.didYouMean, "boolean");
+        assert.equal(typeof result.from.text.value, "string");
+        assert.equal(typeof result.from.text.autoCorrected, "boolean");
+        assert.equal(typeof result.from.text.didYouMean, "boolean");
+    });
+});


### PR DESCRIPTION
Adds the library's first automated test suite, built on Node's built-in `node:test` runner — no test framework, no new dependencies.

- **languages** — `getCode` resolution: codes, names, script-subtag casing, and unknowns
- **request building** — query construction, name→code resolution, the repeated `dt` serialization, and the GET→POST switch, asserted against the request captured off a mocked dispatcher
- **response parsing** — the response-array → result transformation, one branch per case, against canned bodies
- **errors** — the validation and response-error rejections
- **smoke** — one live call to the real endpoint, asserting only that the response still parses into our shape, never its content (that's Google's concern)

Mocked tests run through the public `options.dispatcher` option, so nothing internal is stubbed. Lint moves to its own `npm run lint` step, separate from `npm test`.

Also fixes a latent bug: `translate(text, null)` threw because `typeof null === "object"` slipped past the options guard; it now defaults like a missing argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)