### PR TITLE
Publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,6 +22,4 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run lint
-      - run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
Switches the release workflow from a long-lived `npm_token` secret to npm's OIDC trusted publishing: GitHub's id-token authenticates the publish, and npm generates provenance automatically.

- drops `NODE_AUTH_TOKEN` and the `npm_token` secret
- publishes with `--access public`

**One-time setup required on npmjs.com before the next release:** add a trusted publisher for `@iamtraction/google-translate` -> GitHub Actions, repository `iamtraction/google-translate`, workflow `npm-publish.yml`. Once it's set, the `npm_token` repo secret can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)