### PR TITLE
Trigger CI on main

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,9 +4,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Points the CI workflow's `push` and `pull_request` filters at `main` instead of `master`, in preparation for renaming the default branch.

Merge this first; the branch rename (`master` -> `main`) follows. There's a brief window between merge and rename where `master` has no CI trigger, which is fine since the rename happens right after.

Note: this PR may not show its own CI run, since the `pull_request` trigger now targets `main` while this PR's base is still `master` — expected, not a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)